### PR TITLE
fix: Align PTT default key and add Accessibility permission guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ This repository contains two complementary MCP servers for creating a complete v
 
 | Tool | Description |
 |------|-------------|
-| `start_ptt_mode(key?)` | Start PTT mode (default: `cmd_l+s`) |
+| `start_ptt_mode(key?)` | Start PTT mode (default: `cmd_r`) |
 | `stop_ptt_mode()` | Stop PTT mode |
 | `get_ptt_status()` | Get current status |
 | `get_segment_transcription(wait?, timeout?)` | Get transcribed text |
@@ -72,7 +72,7 @@ This repository contains two complementary MCP servers for creating a complete v
 
 ```
 1. start_ptt_mode() called
-2. User presses hotkey (Left Cmd + S)
+2. User presses hotkey (Right Command)
    → Recording starts
 3. User presses hotkey again
    → Recording stops
@@ -85,7 +85,8 @@ This repository contains two complementary MCP servers for creating a complete v
 
 | Key | Description |
 |-----|-------------|
-| `cmd_l+s` | Left Command + S (default) |
+| `cmd_r` | Right Command (default, recommended) |
+| `cmd_l+s` | Left Command + S |
 | `cmd_r+m` | Right Command + M |
 | `cmd_l`, `cmd_r` | Command keys alone |
 | `alt_l`, `alt_r` | Option keys |

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Claude will speak its responses aloud.
 ```
 
 Full voice loop:
-1. Press **Left Cmd + S** to start recording
+1. Press **Right Command** to start recording
 2. Speak your message
-3. Press **Left Cmd + S** again to stop
+3. Press **Right Command** again to stop
 4. Claude transcribes and responds vocally
 5. Repeat!
 
@@ -208,8 +208,8 @@ Say **"fin de session"** to end the conversation.
 
 | Key | Description |
 |-----|-------------|
-| `cmd_l+s` | Left Command + S (default) |
-| `cmd_r` | Right Command (recommended for MacBooks) |
+| `cmd_r` | Right Command (default, recommended) |
+| `cmd_l+s` | Left Command + S |
 | `cmd_r+m` | Right Command + M |
 | `alt_l`, `alt_r` | Option keys |
 | `f13`, `f14`, `f15` | Function keys |
@@ -303,9 +303,29 @@ say "Hello world"
 ~/.mcp-claude-say/venv/bin/python -c "import sounddevice; print(sounddevice.query_devices())"
 ```
 
-### PTT key not detected
+### PTT key not detected (especially in VSCode)
 
-Make sure Claude Code (or Terminal) has Accessibility permissions in System Settings > Privacy & Security > Accessibility.
+The PTT hotkey uses `pynput` which requires **Accessibility permissions** on macOS. Without these permissions, the keyboard listener starts successfully but never receives key events.
+
+**To fix:**
+
+1. Open **System Settings** → **Privacy & Security** → **Accessibility**
+2. Click the **+** button (unlock with your password if needed)
+3. Add your terminal application:
+   - For VSCode: `/Applications/Visual Studio Code.app`
+   - For Cursor: `/Applications/Cursor.app`
+   - For Terminal: `/Applications/Utilities/Terminal.app`
+   - For iTerm2: `/Applications/iTerm.app`
+4. **Enable the checkbox** next to the app
+5. **Restart the application completely** (quit and reopen)
+
+**Still not working?**
+
+- Try a different hotkey: `start_ptt_mode("f13")` or `start_ptt_mode("alt_r")`
+- Check logs: `tail -f /tmp/claude-listen.log`
+- Verify pynput works: Run a simple pynput test script outside of Claude Code
+
+**Note:** Some keys may work without Accessibility permissions (like function keys F13-F15), but modifier keys (Cmd, Alt, Ctrl) always require permissions.
 
 ## Performance
 

--- a/listen/mcp_server.py
+++ b/listen/mcp_server.py
@@ -96,8 +96,13 @@ def start_ptt_mode(key: str = "cmd_r") -> str:
         log.info("PTT controller created, starting...")
         controller.start()
 
-        msg = f"PTT mode activated. Press {key.replace('_', ' ').title()} to toggle recording."
-        log.info(msg)
+        key_display = key.replace('_', ' ').title()
+        msg = f"""PTT mode activated. Press {key_display} to toggle recording.
+
+⚠️ Keys not working? Grant Accessibility permission:
+   System Settings → Privacy & Security → Accessibility → Enable your terminal app (VSCode, Terminal, Cursor, etc.)
+   Then restart the app."""
+        log.info(f"PTT mode activated with key={key}")
         return msg
 
     except Exception as e:

--- a/listen/ptt_controller.py
+++ b/listen/ptt_controller.py
@@ -39,8 +39,8 @@ class PTTState(Enum):
 @dataclass
 class PTTConfig:
     """Configuration for push-to-talk."""
-    # Key to use for PTT (default: left command + s)
-    key: str = "cmd_l+s"
+    # Key to use for PTT (default: right command - no conflicts, works everywhere)
+    key: str = "cmd_r"
 
     # Callback functions
     on_start_recording: Optional[Callable[[], None]] = None

--- a/skill/conversation/SKILL.md
+++ b/skill/conversation/SKILL.md
@@ -23,7 +23,7 @@ Uses **simple Push-to-Talk (PTT)** mode:
 **Synchronous mode (blocking) - RECOMMENDED:**
 | Tool | Description |
 |------|-------------|
-| `start_ptt_mode(key?)` | Start PTT mode (default: Left Cmd + S) |
+| `start_ptt_mode(key?)` | Start PTT mode (default: Right Cmd) |
 | `stop_ptt_mode()` | Stop PTT mode |
 | `get_ptt_status()` | Get PTT state |
 | `get_segment_transcription(wait?, timeout?)` | Wait for transcription (default timeout: 120s). Returns status: [Ready], [Recording...], [Transcribing...] |
@@ -71,20 +71,20 @@ speak_and_wait("Final part that concludes the explanation.", speed=1)  # Only th
 ┌─────────────────────────────────────────────────┐
 │              Push-to-Talk Mode                  │
 │                                                 │
-│  [Left Cmd + S] → Start recording               │
+│  [Right Cmd] → Start recording                  │
 │       │                                         │
 │       │     (records continuously)              │
 │       │                                         │
-│  [Left Cmd + S] → Stop → Save → Transcribe      │
+│  [Right Cmd] → Stop → Save → Transcribe         │
 │       │                                         │
 │       ↓                                         │
 │  Claude responds vocally                        │
 └─────────────────────────────────────────────────┘
 ```
 
-1. User presses **Left Cmd + S** to start recording
+1. User presses **Right Command** to start recording
 2. Audio is captured continuously
-3. User presses **Left Cmd + S** again to stop
+3. User presses **Right Command** again to stop
 4. Audio is saved and transcribed with the configured STT engine
 5. Claude processes and responds **vocally**
 
@@ -92,7 +92,7 @@ speak_and_wait("Final part that concludes the explanation.", speed=1)  # Only th
 
 ```python
 # 1. Start PTT mode
-start_ptt_mode()  # Uses default key: cmd_l+s
+start_ptt_mode()  # Uses default key: cmd_r (Right Command)
 
 # 2. Confirm vocally (short message only)
 speak_and_wait("Prêt.")
@@ -213,9 +213,9 @@ speak_and_wait("Désactivé.")
 
 | Key | Name |
 |-----|------|
-| `cmd_l+s` | Left Command + S (default) |
+| `cmd_r` | Right Command (default, recommended) |
+| `cmd_l+s` | Left Command + S |
 | `cmd_r+m` | Right Command + M |
-| `cmd_r` | Right Command |
 | `cmd_l` | Left Command |
 | `alt_r` | Right Option |
 | `alt_l` | Left Option |


### PR DESCRIPTION
## Summary

Resolve Issue #4 (PTT not working in VSCode) with three complementary fixes:

### 1. Align default PTT key to `cmd_r`
- Eliminates confusion between documentation (cmd_l+s) and actual API default (cmd_r)
- Right Command avoids conflicts with Save hotkey in most applications
- Improves out-of-the-box experience on MacBooks

### 2. Add Accessibility permission guide
- Proactive message from `start_ptt_mode()` guides users without code changes
- Directs to System Settings → Privacy & Security → Accessibility
- Explains that listener starts successfully but receives no events without permissions

### 3. Expand troubleshooting documentation
- Step-by-step instructions for VSCode, Cursor, Terminal, iTerm2
- Includes alternative hotkeys to try (F13, Alt_R, etc.)
- Debug commands to verify pynput and Accessibility setup

## Files Changed
- **listen/ppt_controller.py**: Changed default PTTConfig key from "cmd_l+s" to "cmd_r"
- **listen/mcp_server.py**: Enhanced start_ppt_mode() return message with permission guidance
- **skill/conversation/SKILL.md**: Updated examples and key documentation
- **ARCHITECTURE.md**: Aligned documentation with new default
- **README.md**: Added comprehensive troubleshooting section

## Testing
- [ ] Test PTT with default cmd_r on macOS
- [ ] Verify message appears when calling start_ppt_mode()
- [ ] Test with VSCode after granting Accessibility permissions
- [ ] Verify alternative keys still work (cmd_l+s, f13, etc.)

## Related Issues
Fixes #4 - PTT recording not starting in VSCode

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)