### PR TITLE
feat: Barge-in support - stop TTS with hotkey (cmd_r)

### DIFF
--- a/listen/mcp_server.py
+++ b/listen/mcp_server.py
@@ -31,7 +31,7 @@ log.debug("ptt_controller imported")
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from shared.coordination import (
     signal_stop_speaking, is_speaking, force_stop_tts,
-    wait_for_tts_complete, clear_tts_complete_signal
+    wait_for_tts_complete, clear_tts_complete_signal, clear_barge_in_signal
 )
 log.debug("shared.coordination imported")
 
@@ -58,6 +58,11 @@ def _on_transcription_ready(text: str) -> None:
     log.info(f"Transcription ready: {text[:50]}...")
     _last_transcription = text
     _current_status = "ready"
+
+    # Clear barge-in signal to allow speak_and_wait to work again
+    # This marks the end of the interruption - Claude can speak again
+    clear_barge_in_signal()
+
     _transcription_ready.set()
 
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -15,6 +15,8 @@ You now have access to text-to-speech via the `claude-say` MCP server.
 | `speak(text, voice?, speed?)` | Add text to queue, returns immediately (preferred for natural flow) |
 | `speak_and_wait(text, voice?, speed?)` | Speak and block until complete (use when expecting a response) |
 | `stop_speaking()` | Stop immediately and clear the queue |
+| `start_stop_hotkey(key?)` | Enable stop hotkey (default: cmd_r) - press to stop TTS anytime |
+| `stop_stop_hotkey()` | Disable the stop hotkey |
 
 ### When to use which tool
 
@@ -58,6 +60,20 @@ The skill supports three voice communication modes:
   - Each speak() call stays digestible (4-5 sentences max) but chains logically
 - **Speed**: 1.0 (normal to facilitate understanding)
 - **Deactivation**: "brief mode" / "that's enough" / "ok thanks"
+
+## Starting Voice Mode
+
+When activating /speak mode:
+
+```python
+# 1. Enable stop hotkey so user can interrupt anytime with Right Command
+start_stop_hotkey()
+
+# 2. Confirm activation (brief!)
+speak("Voice mode activated.")
+```
+
+The user can press **Right Command** at any time to stop speech and clear the queue.
 
 ## General Rules
 
@@ -110,9 +126,10 @@ speak("The Controller bridges the two. It receives user actions, calls the Model
 
 ## User Commands
 
+- **Right Command key**: Stop TTS immediately + clear queue (hotkey, instant)
 - **"stop"** / **"silence"**: Call `stop_speaking()` immediately
 - **"skip"** / **"next"**: Call `skip()`
-- **"vocal off"** / **"voice off"**: Disable voice mode (stop using speak)
+- **"vocal off"** / **"voice off"**: Disable voice mode (`stop_stop_hotkey()` then stop using speak)
 - **"brainstorming mode"**: Activate brainstorming mode
 - **"complete mode"**: Activate complete/detailed mode
 - **"brief mode"**: Return to brief mode (default)


### PR DESCRIPTION
## Summary

Implements Phase 3 of the voice conversation design: **barge-in support**. Users can now press `cmd_r` at any time to instantly stop TTS and clear the speech queue.

## Unified Hotkey Behavior (cmd_r)

| Mode | Action |
|------|--------|
| **TTS only** (`/speak`) | Kill TTS + clear queue |
| **Conversation + VAD** | Kill TTS + clear queue + activate mic |
| **Conversation + PTT** | Kill TTS + clear queue + activate mic |

## Changes

### `shared/coordination.py`
- Added `force_stop_tts()` for immediate process termination
  - Uses `pkill` to kill `say`/`afplay` processes instantly
  - Also sets signal file to clear the speech queue

### `listen/mcp_server.py`
- Updated `_ptt_start_recording()` to use `force_stop_tts()` for barge-in
- Immediate TTS stop when user presses hotkey during speech

### `mcp_server.py` (say)
- Added stop hotkey mode for TTS-only (`/speak`) use:
  - `start_stop_hotkey(key?)` - enable hotkey listener (default: cmd_r)
  - `stop_stop_hotkey()` - disable hotkey listener

### `skill/SKILL.md`
- Documented stop hotkey usage in `/speak` mode
- Added startup instructions to enable hotkey
- Updated user commands section

## Test plan
- [ ] Test `/speak` mode: cmd_r stops TTS immediately
- [ ] Test `/conversation` + VAD: cmd_r stops TTS and activates mic
- [ ] Test `/conversation` + PTT: cmd_r stops TTS and activates mic
- [ ] Verify queue is cleared in all cases
- [ ] Test Accessibility permissions warning is shown if needed

## Known limitations
- Requires macOS Accessibility permissions for hotkey detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)